### PR TITLE
fix(setup): Package requirements.txt

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include LICENSE
 include COMMIT_GUIDELINES.md
+include requirements.txt


### PR DESCRIPTION
Add requirements.txt into MANIFEST.in so that setup.py can read dependency from it.
This is necessary for packaging.